### PR TITLE
IT-496: Updating semver-release-action and match-label-action to latest tags

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -20,11 +20,13 @@ runs:
   using: "composite"
   steps:
     - id: bump
-      uses: zwaldowski/match-label-action@14a178a2f6a2df15306eb6212e624d38d9892a66
+      # match-label-action:v5
+      uses: zwaldowski/match-label-action@74600601f0f19eeede58634e04b3cc5188a0d7c3
       with:
         allowed: major,minor,patch
-    - uses: zwaldowski/semver-release-action@a00dfb8ec7361325376dafedffcd62c8bdcbb2fb
-      id: tag
+    - id: tag
+      # semver-release-action:v4
+      uses: zwaldowski/semver-release-action@a6a8309186ccf60c52ea2463a723c78d3b924577
       with:
         bump: ${{ steps.bump.outputs.match }}
         github_token: ${{ inputs.token }}


### PR DESCRIPTION
Nothing seems concerning between updating either of these action references. Providing their compares for reference:
- Match Label Action
  - https://github.com/zwaldowski/match-label-action/compare/74600601f0f19eeede58634e04b3cc5188a0d7c3...14a178a2f6a2df15306eb6212e624d38d9892a66
- Semver Release Action
  - https://github.com/zwaldowski/semver-release-action/compare/a00dfb8ec7361325376dafedffcd62c8bdcbb2fb...a6a8309186ccf60c52ea2463a723c78d3b924577